### PR TITLE
tweak NonlocalMean performance

### DIFF
--- a/src/ReduceNoise/NonlocalMean.jl
+++ b/src/ReduceNoise/NonlocalMean.jl
@@ -85,6 +85,10 @@ function (f::NonlocalMean)(out::AbstractArray{<:NumberLike, 2},
         first(ax)-o:last(ax)+o
     end
     img = PaddedView(zero(eltype(img)), img, padded_axes)
+    # PaddedView's `getindex` has some overhead so we collect it into a dense array
+    # and then pass to OffsetArray. Becuase we're doing a heavy amount of `getindex`
+    # operation, this extra memory allocation worths.
+    img = OffsetArray(collect(img), padded_axes)
     Δₚ = CartesianIndex(oₚ)
     Δₛ = CartesianIndex(ntuple(_->r_s, ndims(img)))
 


### PR DESCRIPTION
PaddedViews's getindex performance isn't very well, so we should
instead collect a dense array, and then offset it.

NonlocalMean requires a heavy amount of getindex operation so this
extra memory allocation worths.

```julia
using ImageNoise, Images, TestImages

gray_img = float.(imresize(testimage("cameraman"), ratio=0.5))
noisy_img = apply_noise(gray_img, AdditiveWhiteGaussianNoise(0.1))

@btime reduce_noise(noisy_img, NonlocalMean(0.1))
# before: 851.542 ms (11 allocations: 257.45 KiB)
# after: 704.672 ms (13 allocations: 521.56 KiB)
```
